### PR TITLE
rather than using #if to re-create .camera when in Unity 5, adapt the…

### DIFF
--- a/Cardboard/Scripts/CardboardPostRender.cs
+++ b/Cardboard/Scripts/CardboardPostRender.cs
@@ -17,9 +17,7 @@ using UnityEngine;
 [RequireComponent(typeof(Camera))]
 public class CardboardPostRender : MonoBehaviour {
 
-#if UNITY_5
-  new public Camera camera { get; private set; }
-#endif
+  public Camera cam { get; private set; }
 
   // Distortion mesh parameters.
 
@@ -41,19 +39,17 @@ public class CardboardPostRender : MonoBehaviour {
   private Matrix4x4 xfm;
 
   void Reset() {
-    camera.clearFlags = CameraClearFlags.Depth;
-    camera.backgroundColor = Color.magenta;  // Should be noticeable if the clear flags change.
-    camera.orthographic = true;
-    camera.orthographicSize = 0.5f;
-    camera.cullingMask = 0;
-    camera.useOcclusionCulling = false;
-    camera.depth = 100;
+    cam.clearFlags = CameraClearFlags.Depth;
+    cam.backgroundColor = Color.magenta;  // Should be noticeable if the clear flags change.
+    cam.orthographic = true;
+    cam.orthographicSize = 0.5f;
+    cam.cullingMask = 0;
+    cam.useOcclusionCulling = false;
+    cam.depth = 100;
   }
 
   void Awake() {
-#if UNITY_5
-    camera = GetComponent<Camera>();
-#endif
+    cam = GetComponent<Camera>();
     Reset();
     meshMaterial = new Material(Shader.Find("Cardboard/UnlitTexture"));
     uiMaterial = new Material(Shader.Find("Cardboard/SolidColor"));
@@ -71,12 +67,12 @@ public class CardboardPostRender : MonoBehaviour {
     float realAspect = (float)Screen.width / Screen.height;
     float fakeAspect = Cardboard.SDK.Profile.screen.width / Cardboard.SDK.Profile.screen.height;
     aspectComparison = fakeAspect / realAspect;
-    camera.orthographicSize = 0.5f * Mathf.Max(1, aspectComparison);
+    cam.orthographicSize = 0.5f * Mathf.Max(1, aspectComparison);
   }
 #endif
 
   void OnRenderObject() {
-    if (Camera.current != camera)
+    if (Camera.current != cam)
       return;
     Cardboard.SDK.UpdateState();
     var correction = Cardboard.SDK.DistortionCorrection;

--- a/Cardboard/Scripts/CardboardPreRender.cs
+++ b/Cardboard/Scripts/CardboardPreRender.cs
@@ -17,22 +17,18 @@ using UnityEngine;
 [RequireComponent(typeof(Camera))]
 public class CardboardPreRender : MonoBehaviour {
 
-#if UNITY_5
-  new public Camera camera { get; private set; }
-#endif
+  public Camera cam { get; private set; }
 
   void Awake() {
-#if UNITY_5
-    camera = GetComponent<Camera>();
-#endif
+    cam = GetComponent<Camera>();
   }
 
   void Reset() {
-    camera.clearFlags = CameraClearFlags.SolidColor;
-    camera.backgroundColor = Color.black;
-    camera.cullingMask = 0;
-    camera.useOcclusionCulling = false;
-    camera.depth = -100;
+    cam.clearFlags = CameraClearFlags.SolidColor;
+	cam.backgroundColor = Color.black;
+	cam.cullingMask = 0;
+	cam.useOcclusionCulling = false;
+    cam.depth = -100;
   }
 
   void OnPreCull() {
@@ -40,7 +36,7 @@ public class CardboardPreRender : MonoBehaviour {
     if (Cardboard.SDK.ProfileChanged) {
       SetShaderGlobals();
     }
-    camera.clearFlags = Cardboard.SDK.VRModeEnabled ?
+    cam.clearFlags = Cardboard.SDK.VRModeEnabled ?
         CameraClearFlags.SolidColor : CameraClearFlags.Nothing;
     var stereoScreen = Cardboard.SDK.StereoScreen;
     if (stereoScreen != null && !stereoScreen.IsCreated()) {

--- a/Cardboard/Scripts/StereoController.cs
+++ b/Cardboard/Scripts/StereoController.cs
@@ -239,15 +239,11 @@ public class StereoController : MonoBehaviour {
     }
   }
 
-#if UNITY_5
-  new public Camera camera { get; private set; }
-#endif
+  public Camera cam { get; private set; }
 
   void Awake() {
     AddStereoRig();
-#if UNITY_5
-    camera = GetComponent<Camera>();
-#endif
+    cam = GetComponent<Camera>();
   }
 
   /// Helper routine for creation of a stereo rig.  Used by the
@@ -268,7 +264,7 @@ public class StereoController : MonoBehaviour {
       head.trackPosition = false;
     }
 #if !UNITY_5
-    if (camera.tag == "MainCamera" && GetComponent<SkyboxMesh>() == null) {
+    if (cam.tag == "MainCamera" && GetComponent<SkyboxMesh>() == null) {
       gameObject.AddComponent<SkyboxMesh>();
     }
 #endif
@@ -310,7 +306,7 @@ public class StereoController : MonoBehaviour {
     // Move the eye so that COI has about the same size onscreen as in the mono camera FOV.
     // The radius affects the horizon location, which is where the screen-size matching has to
     // occur.
-    float scale = proj11 / camera.projectionMatrix[1, 1];  // vertical FOV
+    float scale = proj11 / cam.projectionMatrix[1, 1];  // vertical FOV
     float offset =
         Mathf.Sqrt(radius * radius + (distance * distance - radius * radius) * scale * scale);
     float eyeOffset = (distance - offset) * Mathf.Clamp01(matchMonoFOV) / zScale;
@@ -345,19 +341,19 @@ public class StereoController : MonoBehaviour {
       // Activate the eyes under our control.
       CardboardEye[] eyes = Eyes;
       for (int i = 0, n = eyes.Length; i < n; i++) {
-        eyes[i].camera.enabled = true;
+        eyes[i].cam.enabled = true;
       }
       // Turn off the mono camera so it doesn't waste time rendering.  Remember to reenable.
       // @note The mono camera is left on from beginning of frame till now in order that other game
       // logic (e.g. referring to Camera.main) continues to work as expected.
-      camera.enabled = false;
+      cam.enabled = false;
       renderedStereo = true;
     } else {
       Cardboard.SDK.UpdateState();
       // Make sure any vertex-distorting shaders don't break completely.
-      Shader.SetGlobalMatrix("_RealProjection", camera.projectionMatrix);
-      Shader.SetGlobalMatrix("_FixProjection", camera.cameraToWorldMatrix);
-      Shader.SetGlobalFloat("_NearClip", camera.nearClipPlane);
+      Shader.SetGlobalMatrix("_RealProjection", cam.projectionMatrix);
+      Shader.SetGlobalMatrix("_FixProjection", cam.cameraToWorldMatrix);
+      Shader.SetGlobalFloat("_NearClip", cam.nearClipPlane);
     }
   }
 
@@ -365,7 +361,7 @@ public class StereoController : MonoBehaviour {
     while (true) {
       // If *we* turned off the mono cam, turn it back on for next frame.
       if (renderedStereo) {
-        camera.enabled = true;
+        cam.enabled = true;
         renderedStereo = false;
       }
       yield return new WaitForEndOfFrame();

--- a/Cardboard/Scripts/StereoRenderEffect.cs
+++ b/Cardboard/Scripts/StereoRenderEffect.cs
@@ -18,13 +18,11 @@ using UnityEngine;
 public class StereoRenderEffect : MonoBehaviour {
   private Material material;
 
-#if UNITY_5
-  private new Camera camera;
+  private Camera cam;
 
   void Awake() {
-    camera = GetComponent<Camera>();
+    cam = GetComponent<Camera>();
   }
-#endif
 
   void Start() {
     material = new Material(Shader.Find("Cardboard/SkyboxMesh"));
@@ -37,7 +35,7 @@ public class StereoRenderEffect : MonoBehaviour {
     GL.LoadPixelMatrix(0, width, height, 0);
     // Camera rects are in screen coordinates (bottom left is origin), but DrawTexture takes a
     // rect in GUI coordinates (top left is origin).
-    Rect blitRect = camera.pixelRect;
+    Rect blitRect = cam.pixelRect;
     blitRect.y = height - blitRect.height - blitRect.y;
     RenderTexture oldActive = RenderTexture.active;
     RenderTexture.active = dest;


### PR DESCRIPTION
… code to use a cached reference to the camera in both Unity 4 and 5.
