### PR TITLE
Adding the alpha channel to CardboardReticleShader.shader

### DIFF
--- a/Cardboard/Resources/UI/CardboardReticleShader.shader
+++ b/Cardboard/Resources/UI/CardboardReticleShader.shader
@@ -62,7 +62,7 @@ Shader "Cardboard/CardboardReticle" {
       }
 
       fixed4 frag(fragmentInput i) : SV_Target {
-        fixed4 ret = fixed4(_Color.x, _Color.y, _Color.z, 1.0);
+        fixed4 ret = fixed4(_Color.x, _Color.y, _Color.z, _Color.a);
         return ret;
       }
 


### PR DESCRIPTION
When the alpha channel is used, you can do things like fading the reticle out when it's not relevant. If I recall correctly, the Cardboard Design Lab utilizes fading the cursor in and out for some sections. The alternative otherwise is to enable and disable the object which would be relatively jarring.