### PR TITLE
Replace reference to 404ing URL with new content

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Copyright (c) 2016 Google Inc. All rights reserved.
 For first time users, see the Get Started Guides for [Android Cardboard](https://developers.google.com/vr/unity/get-started-android), [Android Daydream](https://developers.google.com/vr/unity/get-started-controller), and [iOS Cardboard](https://developers.google.com/vr/unity/get-started-ios).
 
 For updates, known issues, upgrade instructions, see:
-[https://developers.google.com/vr/unity/release-notes](https://developers.google.com/vr/unity/release-notes)
+[https://developers.google.com/vr/unity/release-notes](https://developers.google.com/vr/unity/release-notes).

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Copyright (c) 2016 Google Inc. All rights reserved.
 
-For first time users, see:
-[https://developers.google.com/vr/unity/get-started](https://developers.google.com/vr/unity/get-started)
+For first time users, see the Get Started Guides for [Android Cardboard](https://developers.google.com/vr/unity/get-started-android), [Android Daydream](https://developers.google.com/vr/unity/get-started-controller), and [iOS Cardboard](https://developers.google.com/vr/unity/get-started-ios).
 
 For updates, known issues, upgrade instructions, see:
 [https://developers.google.com/vr/unity/release-notes](https://developers.google.com/vr/unity/release-notes)


### PR DESCRIPTION
The link to https://developers.google.com/vr/unity/get-started in the `README.md` file is 404ing. Looks like the generic landing page was removed recently and replaced with 3 specific ones
