### PR TITLE
Fix for two unnecessary GC allocations.

### DIFF
--- a/GoogleVR/Scripts/Controller/GvrController.cs
+++ b/GoogleVR/Scripts/Controller/GvrController.cs
@@ -266,12 +266,13 @@ public class GvrController : MonoBehaviour {
   }
 
   IEnumerator EndOfFrame() {
+    object eof = new WaitForEndOfFrame();
     while (true) {
       // This must be done at the end of the frame to ensure that all GameObjects had a chance
       // to read transient controller state (e.g. events, etc) for the current frame before
       // it gets reset.
       UpdateController();
-      yield return new WaitForEndOfFrame();
+      yield return eof;
     }
   }
 }

--- a/GoogleVR/Scripts/Controller/Internal/ControllerProviders/AndroidNativeControllerProvider.cs
+++ b/GoogleVR/Scripts/Controller/Internal/ControllerProviders/AndroidNativeControllerProvider.cs
@@ -85,12 +85,24 @@ namespace Gvr.Internal {
       internal byte touch_up;
       internal byte recentered;
       internal byte recentering;
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst=GVR_CONTROLLER_BUTTON_COUNT)]
-      internal byte[] button_state;
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst=GVR_CONTROLLER_BUTTON_COUNT)]
-      internal byte[] button_down;
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst=GVR_CONTROLLER_BUTTON_COUNT)]
-      internal byte[] button_up;
+      internal byte button_state_none;
+      internal byte button_state_click;
+      internal byte button_state_home;
+      internal byte button_state_app;
+      internal byte button_state_volume_up;
+      internal byte button_state_volume_down;
+      internal byte button_down_none;
+      internal byte button_down_click;
+      internal byte button_down_home;
+      internal byte button_down_app;
+      internal byte button_down_volume_up;
+      internal byte button_down_volume_down;
+      internal byte button_up_none;
+      internal byte button_up_click;
+      internal byte button_up_home;
+      internal byte button_up_app;
+      internal byte button_up_volume_up;
+      internal byte button_up_volume_down;
       internal long last_orientation_timestamp;
       internal long last_gyro_timestamp;
       internal long last_accel_timestamp;
@@ -209,13 +221,12 @@ namespace Gvr.Internal {
       outState.touchDown = 0 != state.touch_down;
       outState.touchUp = 0 != state.touch_up;
 
-      outState.appButtonDown = 0 != state.button_down[GVR_CONTROLLER_BUTTON_APP];
-      outState.appButtonState = 0 != state.button_state[GVR_CONTROLLER_BUTTON_APP];
-      outState.appButtonUp = 0 != state.button_up[GVR_CONTROLLER_BUTTON_APP];
-      outState.clickButtonDown = 0 != state.button_down[GVR_CONTROLLER_BUTTON_CLICK];
-      outState.clickButtonState = 0 != state.button_state[GVR_CONTROLLER_BUTTON_CLICK];
-      outState.clickButtonUp = 0 != state.button_up[GVR_CONTROLLER_BUTTON_CLICK];
-
+      outState.appButtonDown = 0 != state.button_down_app;
+      outState.appButtonState = 0 != state.button_state_app;
+      outState.appButtonUp = 0 != state.button_up_app;
+      outState.clickButtonDown = 0 != state.button_down_click;
+      outState.clickButtonState = 0 != state.button_state_click;
+      outState.clickButtonUp = 0 != state.button_up_click;
       outState.recentering = 0 != state.recentering;
       outState.recentered = 0 != state.recentered;
     }


### PR DESCRIPTION
- Cache the yield instruction in the update coroutine.
- Don't marshal the button states as arrays.
