### PR TITLE
restores old screen timeout value when GvrViewer is destroyed

### DIFF
--- a/GoogleVR/Scripts/GvrViewer.cs
+++ b/GoogleVR/Scripts/GvrViewer.cs
@@ -333,6 +333,9 @@ public class GvrViewer : MonoBehaviour {
   public Uri DefaultDeviceProfile = null;
   /// @endcond
 
+  // The screen sleep timeout used when instantiating GvrViewer
+  private int oldScreenSleepTimeout;
+
   private void InitDevice() {
     if (device != null) {
       device.Destroy();
@@ -376,7 +379,12 @@ public class GvrViewer : MonoBehaviour {
 #if UNITY_IOS
     Application.targetFrameRate = 60;
 #endif
-    // Prevent the screen from dimming / sleeping
+    // Prevent the screen from dimming / sleeping but remember current value to restore it later
+    oldScreenSleepTimeout = Screen.sleepTimeout;
+    if (oldScreenSleepTimeout >= 0) {
+      // "get" may return the number of seconds while "set" only allows predefined values
+      oldScreenSleepTimeout = SleepTimeout.SystemSetting;
+    }
     Screen.sleepTimeout = SleepTimeout.NeverSleep;
     InitDevice();
     StereoScreen = null;
@@ -537,6 +545,7 @@ public class GvrViewer : MonoBehaviour {
     if (device != null) {
       device.Destroy();
     }
+    Screen.sleepTimeout = oldScreenSleepTimeout;
     if (instance == this) {
       instance = null;
     }


### PR DESCRIPTION
We noticed that the screen dimming did not work anymore after we closed a VR scene. This change restores the old value when `GvrViewer` gets destroyed

Please note: According to [Unity's spec](https://docs.unity3d.com/ScriptReference/Screen-sleepTimeout.html) it is not allowed to set the value to a value other than the predefined ones while getting it returns the number of seconds the value is actually set to. 