### PR TITLE
Update GvrVideoPlayerTexture.cs

### DIFF
--- a/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
+++ b/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
@@ -592,7 +592,7 @@ public class GvrVideoPlayerTexture : MonoBehaviour {
     if (processingRunning) {
       Debug.LogError("CallPluginAtEndOfFrames invoked while already running.");
       Debug.LogError(StackTraceUtility.ExtractStackTrace());
-      return false;
+      yield break;
     }
 
     // Only run while the video is playing.


### PR DESCRIPTION
Error in Unity: Assets/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs(595,7): error CS1622: Cannot return a value from iterators. Use the yield return statement to return a value, or yield break to end the iteration