### PR TITLE
-l option stops Controller Emulator from working in Linux

### DIFF
--- a/GoogleVR/Scripts/Controller/Internal/Emulator/EmulatorClientSocket.cs
+++ b/GoogleVR/Scripts/Controller/Internal/Emulator/EmulatorClientSocket.cs
@@ -109,7 +109,7 @@ namespace Gvr.Internal {
 
 #else
       string processFilename = "bash";
-      string processArguments = string.Format("-l -c \"{0}\"", adbCommand);
+      string processArguments = string.Format(" -c \"{0}\"", adbCommand);
 
       // "command not found" (see http://tldp.org/LDP/abs/html/exitcodes.html)
       int kExitCodeCommandNotFound = 127;


### PR DESCRIPTION
From what I can tell, when Windows is not present, the command to process is this: bash -l -c "adb forward tcp:7003 tcp:7003". The problem is when the -l option is used in the command, the command is interpreted as if coming from a login shell, which - I believe - means that bash isn't looking at the custom environment variables set in the user's .bashrc and .profile files in their home directory. Without looking at those files, bash can't locate the directory containing the adb command in Linux (try running the command above in a terminal or console on Linux, and the result will be a prompt saying adb command not found).

To fix it, I simply removed the -l option from line 112, and now, when running Unity from a terminal or console in Linux distros, the controller emulator works fine. This is paramount for developers to be able to test and work with their project in Unity using the Daydream View controller (or emulator on a phone, in this case).