### PR TITLE
Fix for returning false on iterator function.

### DIFF
--- a/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
+++ b/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
@@ -592,7 +592,7 @@ public class GvrVideoPlayerTexture : MonoBehaviour {
     if (processingRunning) {
       Debug.LogError("CallPluginAtEndOfFrames invoked while already running.");
       Debug.LogError(StackTraceUtility.ExtractStackTrace());
-      return false;
+      yield return null;
     }
 
     // Only run while the video is playing.

--- a/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
+++ b/GoogleVR/Scripts/Video/GvrVideoPlayerTexture.cs
@@ -592,7 +592,7 @@ public class GvrVideoPlayerTexture : MonoBehaviour {
     if (processingRunning) {
       Debug.LogError("CallPluginAtEndOfFrames invoked while already running.");
       Debug.LogError(StackTraceUtility.ExtractStackTrace());
-      yield return null;
+      yield break;
     }
 
     // Only run while the video is playing.


### PR DESCRIPTION
Replaced with yield break in CallPluginAtEndOfFrames() in GvrVideoPlayerTexture.cs.