### PR TITLE
Update PagedScrollBar.cs

### DIFF
--- a/GoogleVR/Demos/Scripts/ScrollingUIDemo/PaginatedScrolling/PagedScrollBar.cs
+++ b/GoogleVR/Demos/Scripts/ScrollingUIDemo/PaginatedScrolling/PagedScrollBar.cs
@@ -65,9 +65,13 @@ public class PagedScrollBar : Scrollbar {
       float offset = value * (pagedScrollRect.PageCount - 1) * pagedScrollRect.PageSpacing;
       pagedScrollRect.SetScrollOffsetOverride(offset);
     } else {
-      // Calculate the desired a value of the scrollbar.
-      float desiredValue = (float)pagedScrollRect.ActivePageIndex / (pagedScrollRect.PageCount - 1);
-
+      float desiredValue;
+      if(pagedScrollRect.PageCount >= 2){
+        // Calculate the desired a value of the scrollbar.
+        desiredValue = (float)pagedScrollRect.ActivePageIndex / (pagedScrollRect.PageCount - 1);
+      } else {
+        desiredValue = 1.0f; 
+      }
       // Animate towards the desired value.
       value = Mathf.Lerp(value, desiredValue, Time.deltaTime * LERP_SPEED);
     }


### PR DESCRIPTION
I'm dynamically generating pages for this system and the way the code was setup if you only have one page the scrollbar handle would be sent to Nan,Nan,Nan and then the graphic raycaster + laserpointer would try to set the reticle to Nan,Nan,Nan . This fix avoids that and prevents a divide by zero error