### PR TITLE
Update GvrReticlePointer to use unscaledDeltaTime

### DIFF
--- a/GoogleVR/Scripts/UI/GvrReticlePointer.cs
+++ b/GoogleVR/Scripts/UI/GvrReticlePointer.cs
@@ -194,9 +194,9 @@ public class GvrReticlePointer : GvrBasePointer {
     float outer_diameter = 2.0f * Mathf.Tan(outer_half_angle_radians);
 
     reticleInnerDiameter =
-        Mathf.Lerp(reticleInnerDiameter, inner_diameter, Time.deltaTime * reticleGrowthSpeed);
+        Mathf.Lerp(reticleInnerDiameter, inner_diameter, Time.unscaledDeltaTime * reticleGrowthSpeed);
     reticleOuterDiameter =
-        Mathf.Lerp(reticleOuterDiameter, outer_diameter, Time.deltaTime * reticleGrowthSpeed);
+        Mathf.Lerp(reticleOuterDiameter, outer_diameter, Time.unscaledDeltaTime * reticleGrowthSpeed);
 
     materialComp.SetFloat("_InnerDiameter", reticleInnerDiameter * reticleDistanceInMeters);
     materialComp.SetFloat("_OuterDiameter", reticleOuterDiameter * reticleDistanceInMeters);


### PR DESCRIPTION
It would be better that the GvrReticlePointer class uses Time.unscaledDeltaTime instead of Time.deltaTime when animating its diameter, because, in some cases, to pause an app Time.timeScale may be set to 0, in which case the reticle wouldn't be animated if Time.deltaTime is used (and some interactable objects, like menus, could still remain interactable, thus making it desirable to still have an animated reticle).