### PR TITLE
Fixed Migration to Unity 5.6 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Please note, we do not accept pull requests.
 
 ## Migration to Unity 5.6
 __The GVR Unity SDK will no longer support Unity versions older than 5.6 as of 1.50.__ Please upgrade to 5.6 via the following steps:
-1. Update the GVR Unity SDK to 1.60.
-2. Migrate to Unity 5.6.0f3. The SDK will import or remove all the necessary libraries.
-3. Update to GVR Unity SDK 1.50 when it becomes available.
+1. Update the GVR Unity SDK to 1.40.
+2. Migrate to Unity 5.6.0f3 or above. The SDK will import or remove all the necessary libraries.
+3. Update to GVR Unity SDK 1.50 or above.
 
 ## Repo Guide
 * __GoogleVRForUnity.unitypackage__. The GoogleVR Unity SDK for importing into Unity GoogleVR projects.


### PR DESCRIPTION
Some GVR Unity SDK version numbers were incorrect and outdated.