### PR TITLE
GvrSettings and GvrCardboardHelpers on ios should use [DllImport("__Internal")] 

### DIFF
--- a/GoogleVR/Scripts/Utilities/GvrActivityHelper.cs
+++ b/GoogleVR/Scripts/Utilities/GvrActivityHelper.cs
@@ -17,7 +17,13 @@ using UnityEngine;
 // Simple static class to abstract out several jni calls that need to be shared
 // between different classes.
 public static class GvrActivityHelper {
+
+#if UNITY_IOS
+  public const string GVR_DLL_NAME = "__Internal";
+#else
   public const string GVR_DLL_NAME = "gvr";
+#endif  // UNITY_IOS
+
   public const string PACKAGE_UNITY_PLAYER = "com.unity3d.player.UnityPlayer";
 
 #if UNITY_ANDROID && !UNITY_EDITOR


### PR DESCRIPTION
I discovered this whilst trying to use `GvrCardboardHelpers.SetViewerProfile()`. 

Issue: [#621](https://github.com/googlevr/gvr-unity-sdk/issues/621)

The current SDK code 1.6 on both IOS and Android is using DLLImport("gvr"). This is incorrect, IOS should be using "__Internal" to call into the GVRSDK which is an embedded library.

With this fix you can correctly call SetViewerProfile.

**To repro:**

- Create a new project in Unity 5.6.1f1
- In Build Settings switch the platform to IOS
- In Project Settings set a bundle id. Also Enable VR, and add Cardboard only
- Import the Unity GVR 1.6 SDK
- Load the demo scene
- Add the following file:
```
TestCardboard.cs:

using System.Collections;
using UnityEngine;

public class TestCardboard : MonoBehaviour {
	void Awake() {
		Debug.Log ("Setting default viewer");
		GvrCardboardHelpers.SetViewerProfile ("http://google.com/cardboard/cfg?p=CgZHb29nbGUSEkNhcmRib2FyZCBJL08gMjAxNR0rGBU9JQHegj0qEAAASEIAAEhCAABIQgAASEJYADUpXA89OggeZnc-Ej6aPlAAYAM");
	}
}
```
- Create an empty game object in the scene and add that script
- In Build Settings, add this scene to the build
- Build 
- In finder open the XCode Workspace for the project just build
- PLAY onto your connected iOS Device
- We are now running in GoogleVR split screen mode
- Press the Google VR Settings Button

**Expected:**
- settings says the viewer is "2015 Cardboard Viewer V2"

**Actual:**
- Settings didn't get our new profile, it says it is the default cardboard viewer.
- In XCode console log we see `DllNotFoundException: Unable to load DLL 'gvr': The specified module could not be found.`

Now, take this fix and re-run. We now see the viewer  is updated.



