### PR TITLE
Adds cursor lock to GvrEditorEmulator

### DIFF
--- a/Assets/GoogleVR/Scripts/GvrEditorEmulator.cs
+++ b/Assets/GoogleVR/Scripts/GvrEditorEmulator.cs
@@ -67,6 +67,7 @@ public class GvrEditorEmulator : MonoBehaviour {
 
     bool rolled = false;
     if (CanChangeYawPitch()) {
+      Cursor.lockState = CursorLockMode.Locked;
       mouseX += Input.GetAxis(AXIS_MOUSE_X) * 5;
       if (mouseX <= -180) {
         mouseX += 360;
@@ -76,10 +77,15 @@ public class GvrEditorEmulator : MonoBehaviour {
       mouseY -= Input.GetAxis(AXIS_MOUSE_Y) * 2.4f;
       mouseY = Mathf.Clamp(mouseY, -85, 85);
     } else if (CanChangeRoll()) {
+      Cursor.lockState = CursorLockMode.Locked;
       rolled = true;
       mouseZ += Input.GetAxis(AXIS_MOUSE_X) * 5;
       mouseZ = Mathf.Clamp(mouseZ, -85, 85);
-    }
+      }
+      else
+      {
+          Cursor.lockState = CursorLockMode.None;
+      }
 
     if (!rolled) {
       // People don't usually leave their heads tilted to one side for long.


### PR DESCRIPTION
Adds cursor lock when changing yaw pitch and roll in the editor. It makes testing easier as the cursor does not interfere with the rest of the editor when the mouse is clicked to simulate a touch event. The cursor is released when alt or ctrl key are released so the touch functionality on the rest of the screen is not compromised