### PR TITLE
Fixed an exception thrown when running KeyboardDemo under il2cpp

### DIFF
--- a/Assets/GoogleVR/Scripts/Keyboard/GvrKeyboard.cs
+++ b/Assets/GoogleVR/Scripts/Keyboard/GvrKeyboard.cs
@@ -18,6 +18,7 @@ using Gvr.Internal;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 // Events to update the keyboard.
 // These values depend on C API keyboard values
@@ -312,6 +313,7 @@ public class GvrKeyboard : MonoBehaviour {
     }
   }
 
+  [AOT.MonoPInvokeCallback (typeof (GvrKeyboard.KeyboardCallback))]
   private static void OnKeyboardCallback(IntPtr closure, GvrKeyboardEvent keyboardEvent) {
     lock (callbacksLock) {
       threadSafeCallbacks.Add(keyboardEvent);


### PR DESCRIPTION
When running the KeyboardDemo under il2cpp, I found that the following exception prevented the keyboard from being shown:

```
E/Unity: NotSupportedException: To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition.
                                            at Gvr.Internal.AndroidNativeKeyboardProvider.gvr_keyboard_create (IntPtr closure, .KeyboardCallback callback) [0x00000] in <filename unknown>:0 
                                            at Gvr.Internal.AndroidNativeKeyboardProvider.Create (.KeyboardCallback keyboardEvent) [0x00000] in <filename unknown>:0 
                                            at GvrKeyboard.Start () [0x00000] in <filename unknown>:0 
```

I found that this exception wasn't thrown when building with Mono, however. I then added the two lines in this PR to add the attribute indicated by the exception message and found that the KeyboardDemo now works as expected with both Mono and il2cpp.
