### PR TITLE
Autoplay fix when delay is very low.

### DIFF
--- a/Assets/GoogleVR/Demos/Scripts/VideoDemo/AutoPlayVideo.cs
+++ b/Assets/GoogleVR/Demos/Scripts/VideoDemo/AutoPlayVideo.cs
@@ -58,8 +58,7 @@ namespace GoogleVR.VideoDemo {
       }
 
       t += Time.deltaTime;
-      if (t >= delay && player != null) {
-        player.Play();
+      if (t >= delay && player != null && player.Play()) {
         done = true;
       }
     }


### PR DESCRIPTION
Autoplay doesn't work when the delay is low(like 0.01f), probably because the video not loaded or player not ready. 
Fixed by checking if Play() was successful else try next frame.