### PR TITLE
Add iOS Daydream controller support

### DIFF
--- a/Assets/GoogleVR/Demos/Scripts/DemoInputManager.cs
+++ b/Assets/GoogleVR/Demos/Scripts/DemoInputManager.cs
@@ -16,6 +16,10 @@
 #define RUNNING_ON_ANDROID_DEVICE
 #endif  // UNITY_ANDROID && !UNITY_EDITOR
 
+#if UNITY_IOS && !UNITY_EDITOR
+#define RUNNING_ON_IOS_DEVICE
+#endif // UNITY_IOS && !UNITY_EDITOR
+
 namespace GoogleVR.Demos {
   using UnityEngine;
   using UnityEngine.UI;
@@ -88,7 +92,11 @@ namespace GoogleVR.Demos {
       }
       // Message canvas will be enabled later when there's a message to display.
       messageCanvas.SetActive(false);
-#if !RUNNING_ON_ANDROID_DEVICE
+#if RUNNING_ON_IOS_DEVICE
+      // On iOS, use the Daydream controller if one's connected, and fall back to the gaze pointer if not.
+      // For notes on enabling iOS Daydream controller support, see iOSNativeControllerProvider.
+      isDaydream = GvrControllerInput.State == GvrConnectionState.Connected;
+#elif !RUNNING_ON_ANDROID_DEVICE
       if (playerSettingsHasDaydream() || playerSettingsHasCardboard()) {
         // The list is populated with valid VR SDK(s), pick the first one.
         gvrEmulatedPlatformType =
@@ -126,7 +134,10 @@ namespace GoogleVR.Demos {
     void Update() {
       UpdateStatusMessage();
 
-#if !RUNNING_ON_ANDROID_DEVICE
+#if RUNNING_ON_IOS_DEVICE
+      isDaydream = GvrControllerInput.State == GvrConnectionState.Connected;
+      SetVRInputMechanism();
+#elif !RUNNING_ON_ANDROID_DEVICE
       UpdateEmulatedPlatformIfPlayerSettingsChanged();
       if ((isDaydream && gvrEmulatedPlatformType == EmulatedPlatformType.Daydream) ||
           (!isDaydream && gvrEmulatedPlatformType == EmulatedPlatformType.Cardboard)) {

--- a/Assets/GoogleVR/Plugins/iOS/DaydreamControllerPlugin.h
+++ b/Assets/GoogleVR/Plugins/iOS/DaydreamControllerPlugin.h
@@ -1,0 +1,23 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "daydream_controller_state.h"
+
+daydream_controller_state DaydreamControllerPlugin_getState();
+
+void DaydreamControllerPlugin_pause();
+
+void DaydreamControllerPlugin_resume();
+
+void DaydreamControllerPlugin_start();

--- a/Assets/GoogleVR/Plugins/iOS/DaydreamControllerPlugin.m
+++ b/Assets/GoogleVR/Plugins/iOS/DaydreamControllerPlugin.m
@@ -1,0 +1,35 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GvrDaydreamController.h"
+
+daydream_controller_state DaydreamControllerPlugin_getState() {
+
+  return [[GvrDaydreamController sharedInstance] getState];
+}
+
+void DaydreamControllerPlugin_pause() {
+
+  [[GvrDaydreamController sharedInstance] pause];
+}
+
+void DaydreamControllerPlugin_resume() {
+
+  [[GvrDaydreamController sharedInstance] resume];
+}
+
+void DaydreamControllerPlugin_start() {
+
+  [[GvrDaydreamController sharedInstance] start];
+}

--- a/Assets/GoogleVR/Plugins/iOS/GvrDaydreamController.h
+++ b/Assets/GoogleVR/Plugins/iOS/GvrDaydreamController.h
@@ -1,0 +1,30 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "daydream_controller_state.h"
+
+@interface GvrDaydreamController : NSObject
+
+- (daydream_controller_state)getState;
+
+- (void)pause;
+
+- (void)resume;
+
+- (void)start;
+
++ (GvrDaydreamController *)sharedInstance;
+
+@end

--- a/Assets/GoogleVR/Plugins/iOS/GvrDaydreamController.m
+++ b/Assets/GoogleVR/Plugins/iOS/GvrDaydreamController.m
@@ -1,0 +1,218 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <CoreBluetooth/CoreBluetooth.h>
+#import "GvrDaydreamController.h"
+#import "daydream_controller_state.h"
+
+#define BATTERY_LEVEL_CHARACTERISTIC_UUID @"2A19"
+#define BATTERY_SERVICE_UUID @"180F"
+#define DAYDREAM_CHARACTERISTIC_UUID @"00000001-1000-1000-8000-00805f9b34fb"
+#define DAYDREAM_SERVICE_UUID @"0000fe55-0000-1000-8000-00805f9b34fb"
+
+GvrDaydreamController *_sharedInstance = nil;
+
+@implementation GvrDaydreamController {
+  CBUUID *_batteryLevelCharacteristicUuid;
+  CBUUID *_batteryServiceUuid;
+  CBUUID *_daydreamCharacteristicUuid;
+  CBUUID *_daydreamServiceUuid;
+  CBCentralManager *_manager;
+  CBPeripheral *_peripheral;
+  CBCharacteristic *_characteristic;
+  CBCharacteristic *_batteryLevelCharacteristic;
+  daydream_controller_state _state;
+}
+
+- (id)init {
+
+  if (self = [super init]) {
+    _batteryLevelCharacteristicUuid = [CBUUID UUIDWithString:BATTERY_LEVEL_CHARACTERISTIC_UUID];
+    _batteryServiceUuid = [CBUUID UUIDWithString:BATTERY_SERVICE_UUID];
+    _daydreamCharacteristicUuid = [CBUUID UUIDWithString:DAYDREAM_CHARACTERISTIC_UUID];
+    _daydreamServiceUuid = [CBUUID UUIDWithString:DAYDREAM_SERVICE_UUID];
+    _manager = nil;
+    [self _clearControllerState];
+  }
+  return self;
+}
+
+- (void)disconnect {
+
+  [self pause];
+  if (_peripheral && _manager) {
+    [_manager cancelPeripheralConnection:_peripheral];
+    [self _clearControllerState];
+  }
+}
+
+- (daydream_controller_state)getState {
+
+  return _state;
+}
+
+- (void)pause {
+
+  [self _setNotifyValues:false];
+}
+
+- (void)resume {
+
+  [self _setNotifyValues:true];
+}
+
+- (void)start {
+
+  if (!_manager) {
+    dispatch_queue_attr_t qosAttribute = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INTERACTIVE, 0);
+    dispatch_queue_t queue = dispatch_queue_create("vr.daydreamcontroller", qosAttribute);
+    _manager = [[CBCentralManager alloc] initWithDelegate:self queue:queue];
+  }
+  if (_peripheral) {
+    if (_peripheral.state == CBPeripheralStateDisconnected) {
+      [self _connectPeripheral:_peripheral];
+    } else {
+      [self resume];
+    }
+  }
+}
+
++ (GvrDaydreamController *)sharedInstance {
+
+  if (!_sharedInstance) {
+    _sharedInstance = [GvrDaydreamController new];
+  }
+  return _sharedInstance;
+}
+
+// see CBCentralManagerDelegate
+- (void)centralManagerDidUpdateState:(CBCentralManager *)centralManager {
+
+  if (centralManager.state == CBCentralManagerStatePoweredOn) {
+    NSArray *connectedPeripherals = [centralManager retrieveConnectedPeripheralsWithServices:@[_daydreamServiceUuid]];
+    if ([connectedPeripherals count]) {
+      [self _handleDiscoveredPeripheral:connectedPeripherals[0]];
+      return;
+    }
+    [centralManager scanForPeripheralsWithServices:@[_daydreamServiceUuid] options: nil];
+  } else {
+    [self _clearControllerState];
+  }
+}
+
+// see CBCentralManagerDelegate
+- (void)centralManager:(CBCentralManager *)centralManager
+    didDiscoverPeripheral:(CBPeripheral *)peripheral
+    advertisementData:(NSDictionary<NSString *,id> *)advertisementData
+    RSSI:(NSNumber *)RSSI {
+
+  [_manager stopScan];
+  [self _handleDiscoveredPeripheral:peripheral];
+}
+
+// see CBCentralManagerDelegate
+- (void)centralManager:(CBCentralManager *)centralManager didConnectPeripheral:(CBPeripheral *)peripheral {
+
+  _state.connectionState = GVR_CONTROLLER_CONNECTED;
+  [peripheral discoverServices:@[_daydreamServiceUuid, _batteryServiceUuid]];
+}
+
+// see CBCentralManagerDelegate
+- (void)centralManager:(CBCentralManager *)centralManager didDisconnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
+
+  [self _clearControllerState];
+}
+
+// see CBPeripheralDelegate
+- (void)centralManager:(CBCentralManager *)centralManager didFailToConnect:(CBPeripheral *)peripheral error:(NSError *)error {
+
+  [self _clearControllerState];
+}
+
+// see CBPeripheralDelegate
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverServices:(NSError *)error {
+
+  for (CBService *service in peripheral.services) {
+    if ([service.UUID isEqual:_daydreamServiceUuid]) {
+      [peripheral discoverCharacteristics:@[_daydreamCharacteristicUuid] forService:service];
+    } else if ([service.UUID isEqual:_batteryServiceUuid]) {
+      [peripheral discoverCharacteristics:@[_batteryLevelCharacteristicUuid] forService:service];
+    }
+  }
+}
+
+// see CBPeripheralDelegate
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverCharacteristicsForService:(CBService *)service error:(NSError *)error {
+
+  for (CBCharacteristic *characteristic in service.characteristics) {
+    if ([characteristic.UUID isEqual:_daydreamCharacteristicUuid]) {
+      _characteristic = characteristic;
+      [_peripheral setNotifyValue:true forCharacteristic:characteristic];
+    } else if ([characteristic.UUID isEqual:_batteryLevelCharacteristicUuid]) {
+      _state.supportsBatteryStatus = true;
+      _batteryLevelCharacteristic = characteristic;
+      [_peripheral readValueForCharacteristic:characteristic];
+      [_peripheral setNotifyValue:true forCharacteristic:characteristic];
+    }
+  }
+}
+
+// see CBPeripheralDelegate
+- (void)peripheral:(CBPeripheral *)peripheral didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
+
+  if ([characteristic isEqual:_characteristic]) {
+    NSData *sensorData = characteristic.value;
+    if (sensorData.length != 20) {
+      return;
+    }
+    _state = get_next_daydream_controller_state(sensorData.bytes, _state);
+  } else if ([characteristic isEqual:_batteryLevelCharacteristic]) {
+    NSData *batteryData = characteristic.value;
+    if (batteryData.length != 1) {
+      return;
+    }
+    _state.batteryLevelPercentage = ((UInt8 *)batteryData.bytes)[0];
+  }
+}
+
+- (void)_clearControllerState {
+
+  _peripheral = nil;
+  _state = get_initial_daydream_controller_state();
+}
+
+- (void)_connectPeripheral:(CBPeripheral *)peripheral {
+
+  _state.connectionState = GVR_CONTROLLER_CONNECTING;
+  [_manager connectPeripheral:peripheral options:nil];
+}
+
+- (void)_handleDiscoveredPeripheral:(CBPeripheral *)peripheral {
+
+  _peripheral = peripheral;
+  _peripheral.delegate = self;
+  [self _connectPeripheral:_peripheral];
+}
+
+- (void)_setNotifyValues:(BOOL)enabled {
+
+  if (_peripheral && _characteristic) {
+    [_peripheral setNotifyValue:enabled forCharacteristic:_characteristic];
+  }
+  if (_peripheral && _batteryLevelCharacteristic) {
+    [_peripheral setNotifyValue:enabled forCharacteristic:_batteryLevelCharacteristic];
+  }
+}
+
+@end

--- a/Assets/GoogleVR/Plugins/iOS/daydream_controller_state.h
+++ b/Assets/GoogleVR/Plugins/iOS/daydream_controller_state.h
@@ -1,0 +1,61 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <stdint.h>
+
+typedef struct {
+  float x;
+  float y;
+  float z;
+  float w;
+} gvr_quat;
+
+typedef struct {
+  float x;
+  float y;
+  float z;
+} gvr_vec3;
+
+typedef struct {
+  float x;
+  float y;
+} gvr_vec2;
+
+typedef enum {
+  GVR_CONTROLLER_DISCONNECTED = 0,
+  GVR_CONTROLLER_SCANNING = 1,
+  GVR_CONTROLLER_CONNECTING = 2,
+  GVR_CONTROLLER_CONNECTED = 3
+} controller_connection_state;
+
+typedef struct {
+  controller_connection_state connectionState;
+  gvr_quat orientation;
+  gvr_vec3 accel;
+  gvr_vec3 gyro;
+  gvr_vec2 touchPos;
+  bool isTouching;
+  bool appButtonState;
+  bool homeButtonState;
+  bool clickButtonState;
+  bool plusButtonState;
+  bool minusButtonState;
+  bool supportsBatteryStatus;
+  uint8_t batteryLevelPercentage;
+} daydream_controller_state;
+
+daydream_controller_state get_initial_daydream_controller_state();
+
+// `data` is a pointer to a 20-byte buffer with the Bluetooth data from the controller
+daydream_controller_state get_next_daydream_controller_state(UInt8 *data, daydream_controller_state previousState);

--- a/Assets/GoogleVR/Plugins/iOS/daydream_controller_state.m
+++ b/Assets/GoogleVR/Plugins/iOS/daydream_controller_state.m
@@ -1,0 +1,115 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <math.h>
+#import <GLKit/GLKit.h>
+#import "daydream_controller_state.h"
+
+#define QUATERNION_IDENTITY (gvr_quat){ GLKQuaternionIdentity.x, GLKQuaternionIdentity.y, GLKQuaternionIdentity.z, GLKQuaternionIdentity.w }
+#define ORIENTATION_SCALE (2.0 * M_PI / 4095.0)
+#define ACCELEROMETER_SCALE (9.8 * 8.0 / 4095.0)
+#define GYRO_SCALE (M_PI * 2048.0 / 4095.0 / 180.0)
+
+daydream_controller_state get_initial_daydream_controller_state() {
+
+  return (daydream_controller_state) {
+    .connectionState = GVR_CONTROLLER_DISCONNECTED,
+    .orientation = QUATERNION_IDENTITY,
+    .accel = (gvr_vec3){ 0, 0, 0 },
+    .gyro = (gvr_vec3){ 0, 0, 0 },
+    .touchPos = (gvr_vec2){ 0, 0 },
+    .isTouching = false,
+    .appButtonState = false,
+    .homeButtonState = false,
+    .clickButtonState = false,
+    .plusButtonState = false,
+    .minusButtonState = false,
+    .supportsBatteryStatus = false,
+    .batteryLevelPercentage = 0
+  };
+}
+
+daydream_controller_state get_next_daydream_controller_state(uint8_t *data, daydream_controller_state previousState) {
+
+  // raw orientation 13 bit signed int
+  int16_t ox = (int16_t)(((uint16_t)data[1] << 14) | ((uint16_t)data[2] << 6) | ((uint16_t)(data[3] & 0b11100000) >> 2)) >> 3;
+  int16_t oy = (int16_t)(((uint16_t)data[3] << 11) | ((uint16_t)data[4] << 3)) >> 3;
+  int16_t oz = (int16_t)(((uint16_t)data[5] <<  8) | ((uint16_t)(data[6] & 0b11111000))) >> 3;
+  // raw accelerometer 13 bit signed int
+  int16_t ax = (int16_t)(((uint16_t)data[6] << 13) | ((uint16_t)data[7] << 5) | ((uint16_t)(data[8] & 0b11000000) >> 1)) >> 3;
+  int16_t ay = (int16_t)(((uint16_t)data[8] << 10) | ((uint16_t)(data[9] & 0b11111110) << 2)) >> 3;
+  int16_t az = (int16_t)(((uint16_t)data[9] << 15) | ((uint16_t)data[10] << 7) | ((uint16_t)(data[11] & 0b11110000) >> 1)) >> 3;
+  // raw gyroscope 13 bit signed int, unit = 0.5 * degrees per second
+  int16_t gx = (int16_t)(((uint16_t)data[11] << 12) | ((uint16_t)data[12] << 4) | ((uint16_t)(data[13] & 0b10000000) >> 4)) >> 3;
+  int16_t gy = (int16_t)(((uint16_t)data[13] <<  9) | ((uint16_t)(data[14] & 0b11111100) << 1)) >> 3;
+  int16_t gz = (int16_t)(((uint16_t)data[14] << 14) | ((uint16_t)data[15] << 6) | ((uint16_t)(data[16] & 0b11100000) >> 2)) >> 3;
+  // touchpad x, y with 0 - 255
+  uint8_t tx = (data[16] << 3) | (data[17] >> 5);
+  uint8_t ty = (data[17] << 3) | (data[18] >> 5);
+  // buttons
+  uint8_t buttonFlags = data[18] & 0b00011111;
+  // last byte unknown or reserved
+
+  // orientation is represented as axis-angles with magnitude as rotation angle theta around that vector
+  float x = (float)ox * ORIENTATION_SCALE;
+  float y = (float)oy * ORIENTATION_SCALE;
+  float z = (float)oz * ORIENTATION_SCALE;
+  float magnitudeSquare = x * x + y * y + z * z;
+
+  gvr_quat orientation;
+  if (0.0 < magnitudeSquare) {
+    float magnitude = sqrt(magnitudeSquare); // same as axis angle
+    float scale = 1.0 / magnitude;
+    GLKQuaternion glkOrientation = GLKQuaternionMakeWithAngleAndAxis(magnitude, x * scale, y * scale, z * scale);
+    orientation = (gvr_quat){ glkOrientation.x, glkOrientation.y, glkOrientation.z, glkOrientation.w };
+  } else {
+    orientation = QUATERNION_IDENTITY;
+  }
+
+  gvr_vec3 accel = (gvr_vec3) {
+    .x = (float)ax * ACCELEROMETER_SCALE,
+    .y = (float)ay * ACCELEROMETER_SCALE,
+    .z = (float)az * ACCELEROMETER_SCALE
+  };
+
+  gvr_vec3 gyro = (gvr_vec3) {
+    .x = (float)gx * GYRO_SCALE,
+    .y = (float)gy * GYRO_SCALE,
+    .z = (float)gz * GYRO_SCALE
+  };
+
+  // The touch position from upper left (0, 0) to lower right (1, 1).
+  gvr_vec2 touchPos = (gvr_vec2) {
+    .x = (float)tx / 255.0,
+    .y = (float)ty / 255.0
+  };
+
+  daydream_controller_state state = (daydream_controller_state) {
+    .connectionState = previousState.connectionState,
+    .orientation = orientation,
+    .accel = accel,
+    .gyro = gyro,
+    .touchPos = touchPos,
+    .isTouching = (0 < tx || 0 < ty),
+    .clickButtonState = (0 < (buttonFlags & 0b00001)),
+    .homeButtonState  = (0 < (buttonFlags & 0b00010)),
+    .appButtonState   = (0 < (buttonFlags & 0b00100)),
+    .plusButtonState  = (0 < (buttonFlags & 0b01000)),
+    .minusButtonState = (0 < (buttonFlags & 0b10000)),
+    .supportsBatteryStatus = previousState.supportsBatteryStatus,
+    .batteryLevelPercentage = previousState.batteryLevelPercentage
+  };
+
+  return state;
+}

--- a/Assets/GoogleVR/Scripts/Controller/Internal/ControllerProviderFactory.cs
+++ b/Assets/GoogleVR/Scripts/Controller/Internal/ControllerProviderFactory.cs
@@ -31,6 +31,9 @@ namespace Gvr.Internal {
 #elif UNITY_ANDROID
       // Use the GVR C API.
       return new AndroidNativeControllerProvider();
+#elif UNITY_IOS && GVR_IOS_DAYDREAM_CONTROLLER_ENABLED
+      // Use the native iOS plugin.
+      return new iOSNativeControllerProvider();
 #else
       // Platform not supported.
       Debug.LogWarning("No controller support on this platform.");

--- a/Assets/GoogleVR/Scripts/Controller/Internal/ControllerProviders/iOSNativeControllerProvider.cs
+++ b/Assets/GoogleVR/Scripts/Controller/Internal/ControllerProviders/iOSNativeControllerProvider.cs
@@ -1,0 +1,241 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#if UNITY_IOS && !UNITY_EDITOR && GVR_IOS_DAYDREAM_CONTROLLER_ENABLED
+using UnityEngine;
+
+using System;
+using System.Runtime.InteropServices;
+using System.Timers;
+
+/// @cond
+namespace Gvr.Internal {
+
+  /// Controller Provider that uses a native iOS plugin to communicate with a controller.
+  /// In the iOS player settings, "XR Settings" -> "Virtual Reality SDKs" does not list "Daydream" as an option.
+  /// So, to enable iOS Daydream controller support, include "Cardboard" in "Virtual Reality SDKs" and add the flag
+  /// GVR_IOS_DAYDREAM_CONTROLLER_ENABLED in "Other Settings" -> "Scripting Define Symbols". This will make it so
+  /// that the XCode project includes CoreBluetooth as a dependency and includes NSBluetoothPeripheralUsageDescription
+  /// in its Info.plist.
+  class iOSNativeControllerProvider : IControllerProvider {
+    // enum gvr_controller_connection_state:
+    private const int GVR_CONTROLLER_DISCONNECTED = 0;
+    private const int GVR_CONTROLLER_SCANNING = 1;
+    private const int GVR_CONTROLLER_CONNECTING = 2;
+    private const int GVR_CONTROLLER_CONNECTED = 3;
+
+    private enum controller_connection_state : int {
+      DISCONNECTED = 0,
+      SCANNING = 1,
+      CONNECTING = 2,
+      CONNECTED = 3
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct gvr_quat {
+      internal float x;
+      internal float y;
+      internal float z;
+      internal float w;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct gvr_vec3 {
+      internal float x;
+      internal float y;
+      internal float z;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct gvr_vec2 {
+      internal float x;
+      internal float y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct daydream_controller_state {
+      internal controller_connection_state connectionState;
+      internal gvr_quat orientation;
+      internal gvr_vec3 accel;
+      internal gvr_vec3 gyro;
+      internal gvr_vec2 touchPos;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool isTouching;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool appButtonState;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool homeButtonState;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool clickButtonState;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool plusButtonState;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool minusButtonState;
+      [MarshalAs(UnmanagedType.U1)]
+      internal bool supportsBatteryStatus;
+      internal byte batteryLevelPercentage;
+    }
+
+    [DllImport ("__Internal")]
+    private static extern daydream_controller_state DaydreamControllerPlugin_getState();
+
+    [DllImport ("__Internal")]
+    private static extern void DaydreamControllerPlugin_pause();
+
+    [DllImport ("__Internal")]
+    private static extern void DaydreamControllerPlugin_resume();
+
+    [DllImport ("__Internal")]
+    private static extern void DaydreamControllerPlugin_start();
+
+    private bool supportsBatteryStatus = false;
+
+    private MutablePose3D pose3d = new MutablePose3D();
+
+    private bool lastTouchState;
+    private bool lastButtonState;
+    private bool lastAppButtonState;
+    private bool lastHomeButtonState;
+
+    // Y axis rotation offset for recentering.
+    private float yAxisRotationOffset = 0;
+    private Timer recenterTimer = new Timer();
+    private bool recenterOnNextReadState = false;
+
+    public iOSNativeControllerProvider() {
+      // Timer to wait for the home button to be held down 1 second before recentering.
+      recenterTimer.Interval = 1000;
+      recenterTimer.AutoReset = false;
+      recenterTimer.Elapsed += RecenterTimer_Elapsed;
+      DaydreamControllerPlugin_start();
+    }
+
+    public bool SupportsBatteryStatus { get { return supportsBatteryStatus; }}
+
+    /// Notifies the controller provider that the application has paused.
+    public void OnPause() {
+
+      DaydreamControllerPlugin_pause();
+    }
+
+    /// Notifies the controller provider that the application has resumed.
+    public void OnResume() {
+
+      DaydreamControllerPlugin_resume();
+    }
+
+    /// Reads the controller's current state and stores it in outState.
+    public void ReadState(ControllerState outState) {
+      outState.apiStatus = GvrControllerApiStatus.Ok;
+      daydream_controller_state newState = DaydreamControllerPlugin_getState();
+      outState.connectionState = ConvertConnectionState(newState.connectionState);
+
+      gvr_quat rawOri = newState.orientation;
+      gvr_vec3 rawAccel = newState.accel;
+      gvr_vec3 rawGyro = newState.gyro;
+
+      // Convert GVR API orientation (right-handed) into Unity axis system (left-handed).
+      pose3d.Set(Vector3.zero, new Quaternion(rawOri.x, rawOri.y, rawOri.z, rawOri.w));
+      pose3d.SetRightHanded(pose3d.Matrix);
+
+      // The orientation without the Y rotation offset from the last recenter event.
+      var orientationBeforeYAxisOffset = pose3d.Orientation.eulerAngles;
+
+      // For accelerometer, we have to flip Z because the GVR API has Z pointing backwards
+      // and Unity has Z pointing forward.
+      outState.accel = new Vector3(rawAccel.x, rawAccel.y, -rawAccel.z);
+
+      outState.gyro = new Vector3(-rawGyro.x, -rawGyro.y, rawGyro.z);
+
+      outState.isTouching = newState.isTouching;
+
+      outState.touchPos = new Vector2(newState.touchPos.x, newState.touchPos.y);
+
+      outState.appButtonState = newState.appButtonState;
+      outState.homeButtonState = newState.homeButtonState;
+      outState.clickButtonState = newState.clickButtonState;
+
+      UpdateInputEvents(outState.isTouching, ref lastTouchState,
+        ref outState.touchUp, ref outState.touchDown);
+      UpdateInputEvents(outState.clickButtonState, ref lastButtonState,
+        ref outState.clickButtonUp, ref outState.clickButtonDown);
+      UpdateInputEvents(outState.appButtonState, ref lastAppButtonState,
+        ref outState.appButtonUp, ref outState.appButtonDown);
+      UpdateInputEvents(outState.homeButtonState, ref lastHomeButtonState,
+        ref outState.homeButtonUp, ref outState.homeButtonDown);
+
+      if (outState.homeButtonDown) {
+        recenterTimer.Start();
+      }
+      if (outState.homeButtonUp) {
+        recenterTimer.Stop();
+      }
+
+      outState.recentered = recenterOnNextReadState;
+      if (outState.recentered) {
+        recenterOnNextReadState = false;
+        GvrCardboardHelpers.Recenter();
+        yAxisRotationOffset = orientationBeforeYAxisOffset.y;
+      }
+      outState.orientation = Quaternion.Euler(orientationBeforeYAxisOffset.x, orientationBeforeYAxisOffset.y - yAxisRotationOffset, orientationBeforeYAxisOffset.z);
+
+      supportsBatteryStatus = newState.supportsBatteryStatus;
+      if (supportsBatteryStatus) {
+        outState.batteryLevel = ConvertBatteryLevel(newState.batteryLevelPercentage);
+      }
+    }
+
+    private void RecenterTimer_Elapsed(object sender, ElapsedEventArgs e) {
+      // The user has been holding down the home button for long enough to trigger a recenter.
+      recenterOnNextReadState = true;
+    }
+
+    private static void UpdateInputEvents(bool currentState, ref bool previousState, ref bool up, ref bool down) {
+
+      down = !previousState && currentState;
+      up = previousState && !currentState;
+
+      previousState = currentState;
+    }
+
+    private GvrControllerBatteryLevel ConvertBatteryLevel(byte batteryLevelPercentage) {
+      if (batteryLevelPercentage >= 80) {
+        return GvrControllerBatteryLevel.Full;
+      } else if (batteryLevelPercentage >= 60) {
+        return GvrControllerBatteryLevel.AlmostFull;
+      } else if (batteryLevelPercentage >= 40) {
+        return GvrControllerBatteryLevel.Medium;
+      } else if (batteryLevelPercentage >= 20) {
+        return GvrControllerBatteryLevel.Low;
+      } else {
+        return GvrControllerBatteryLevel.CriticalLow;
+      }
+    }
+
+    private GvrConnectionState ConvertConnectionState(controller_connection_state connectionState) {
+      switch (connectionState) {
+        case controller_connection_state.CONNECTED:
+          return GvrConnectionState.Connected;
+        case controller_connection_state.CONNECTING:
+          return GvrConnectionState.Connecting;
+        case controller_connection_state.SCANNING:
+          return GvrConnectionState.Scanning;
+        default:
+          return GvrConnectionState.Disconnected;
+      }
+    }
+  }
+}
+/// @endcond
+
+#endif // UNITY_IOS && !UNITY_EDITOR && GVR_IOS_DAYDREAM_CONTROLLER_ENABLED


### PR DESCRIPTION
# Add iOS Daydream Controller Support

With the introduction of the high-resolution iPhone X, iOS is becoming a viable platform for VR applications. I think now is a good time to introduce iOS Daydream controller support, and this PR achieves that using the approach I use in my [Viewport VR Browser app](https://www.viewport.org/). For a demo of the changes in this PR, check out [this repo](https://github.com/BinaryNate/iOSDaydreamControllerDemo).

I owe much of the credit for this integration to @cwei, whose [DaydreamController Swift project](https://github.com/cwei/DaydreamController) served as the reference implementation. Carsten kindly gave me permission to use his approach in my work.

## Rationale

Although my app supports both the gaze pointer and the Daydream controller, the Daydream controller provides a significantly better user experience. The issue today is that very few iOS users have Daydream controllers, because Daydream controller support in iOS apps is rare. My hope is that by adding iOS Daydream controller support to the GVR Unity SDK, we will bolster an ecosystem of compatible apps in the App Store and thus increase the number of iOS users with Daydream controllers. I believe this benefits everyone: developers can offer similar experiences on Android and iOS, iOS users benefit from the increased number of apps that support controllers, and Google can sell more Daydream headsets. I'd really love to get this controller support merged in, so I'm happy to work with you to make any changes required.

## Details

iOSNativeControllerProvider.cs details how to enable Daydream controller support on iOS:

> In the iOS player settings, "XR Settings" -> "Virtual Reality SDKs" does not list "Daydream" as an option. So, to enable iOS Daydream controller support, include "Cardboard" in "Virtual Reality SDKs" and add the flag GVR_IOS_DAYDREAM_CONTROLLER_ENABLED in "Other Settings" -> "Scripting Define Symbols". This will make it so that the XCode project includes CoreBluetooth as a dependency and includes NSBluetoothPeripheralUsageDescription in its Info.plist.

Originally, I was hoping to add "Daydream" as an option in *"XR Settings" -> "Virtual Reality SDKs"*, but it appears that those options are baked into Unity, and I haven't yet found a way to modify them. For now, the `GVR_IOS_DAYDREAM_CONTROLLER_ENABLED` flag seems like a reasonable way to keep Daydream controller support disabled by default, although I'm definitely open to using a different approach if you prefer something else.