### PR TITLE
Fixed issue with InstantPreview trying to destroy already destroyed cameras

### DIFF
--- a/Assets/GoogleVR/Scripts/InstantPreview/InstantPreview.cs
+++ b/Assets/GoogleVR/Scripts/InstantPreview/InstantPreview.cs
@@ -378,8 +378,12 @@ namespace Gvr.Internal {
           // Destroys the eye cameras.
           EyeCamera curEyeCamera;
           if (eyeCameras.TryGetValue(oldCamera, out curEyeCamera)) {
-            Destroy(curEyeCamera.leftEyeCamera.gameObject);
-            Destroy(curEyeCamera.rightEyeCamera.gameObject);
+            if (curEyeCamera.leftEyeCamera != null) {
+              Destroy(curEyeCamera.leftEyeCamera.gameObject);
+            }
+            if (curEyeCamera.rightEyeCamera != null) {
+              Destroy(curEyeCamera.rightEyeCamera.gameObject);
+            }
           }
 
           // Removes eye camera entry from dictionary.


### PR DESCRIPTION
Switching between scenes causes the InstantPreview cameras to be destroyed. While checking whether the cameras should be removed it will try to destroy the already destoyed GameObject again. This causes the function to halt and the old cameras to remain in the list. This results in an error message every frame as shown below.

![screen shot 2018-03-13 at 14 12 27](https://user-images.githubusercontent.com/495620/37346826-b0151fa8-26d0-11e8-9c46-ec74248421fc.png)

I added a null-check for the eye cameras. This way already destroyed objects will be skipped, but will still be removed from the list.